### PR TITLE
added selection by min/max workflow versions

### DIFF
--- a/example_scripts/01 - Project Stats and Cleaning Classification Files.ipynb
+++ b/example_scripts/01 - Project Stats and Cleaning Classification Files.ipynb
@@ -23,7 +23,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Python version: 2.7.11, numpy version: 1.11.0, pandas version: 0.19.2. \n",
+      "Python version: 2.7.11, numpy version: 1.11.0, pandas version: 0.19.2.\n",
       "Originally developed using Py 2.7.11, np v1.11.0, pd v0.19.2\n",
       "If these versions don't match and stuff breaks, that's probably why.\n"
      ]
@@ -35,7 +35,12 @@
     "import pandas as pd\n",
     "import ujson\n",
     "\n",
-    "print(\"Python version: %d.%d.%d, numpy version: %s, pandas version: %s. \\nOriginally developed using Py 2.7.11, np v1.11.0, pd v0.19.2\" %(sys.version_info[0], sys.version_info[1], sys.version_info[2], np.__version__, pd.__version__))\n",
+    "print(\"Python version: %d.%d.%d, numpy version: %s, pandas version: %s.\" %(sys.version_info[0], \n",
+    "                                                                           sys.version_info[1], \n",
+    "                                                                           sys.version_info[2], \n",
+    "                                                                           np.__version__, \n",
+    "                                                                           pd.__version__))\n",
+    "print(\"Originally developed using Py 2.7.11, np v1.11.0, pd v0.19.2\")\n",
     "print(\"If these versions don't match and stuff breaks, that's probably why.\")"
    ]
   },
@@ -70,7 +75,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 3,
    "metadata": {
     "collapsed": false
    },
@@ -129,10 +134,12 @@
     "\n",
     "classification_file = project_name + \"-classifications.csv\"\n",
     "\n",
-    "# if you want to do this separately you need to also import read_classfile from basic_classification_processing above\n",
+    "# if you want to do this separately you need to also import read_classfile from \n",
+    "# basic_classification_processing above\n",
     "#classifications = read_classfile(classification_file)\n",
     "\n",
-    "# compute the most basic stats, not worrying about duplicate or non-live classifications or multiple workflows\n",
+    "# compute the most basic stats, not worrying about duplicate or non-live classifications \n",
+    "# or multiple workflows\n",
     "basic_stats_processing(classification_file)"
    ]
   },
@@ -194,6 +201,10 @@
       "    workflow_version=M\n",
       "       specify the program should only consider classifications from workflow version M\n",
       "       (note the program will only consider the major version, i.e. the integer part)\n",
+      "    workflow_ver_min=Mmin, workflow_ver_max=Mmax\n",
+      "       specify the program should consider classifications from workflow version >= Mmin\n",
+      "       or <= Mmax, or Mmin <= workflow version <= Mmax, if both are specified\n",
+      "       Note specifying either a min or max supersedes specifying a workflow_version.\n",
       "    outfile_csv=filename.csv\n",
       "       if you want the program to save a sub-file with only classification info from the workflow specified, give the filename here\n",
       "    --time_elapsed\n",
@@ -299,7 +310,8 @@
     }
    ],
    "source": [
-    "basic_stats_processing(classification_file, workflow_id=5030, remove_duplicates=True, time_elapsed=True)"
+    "basic_stats_processing(classification_file, workflow_id=5030, remove_duplicates=True, \n",
+    "                       time_elapsed=True)"
    ]
   },
   {
@@ -338,7 +350,9 @@
     "outfile_cleanclass = project_name + \"-classifications-workflow5030-version3.8-nodups.csv\"\n",
     "\n",
     "# since we've already printed the stats to the screen above, don't re-print them\n",
-    "basic_stats_processing(classification_file, workflow_id=5030, workflow_version=3.8, remove_duplicates=True, outfile_csv=outfile_cleanclass, keep_allcols=True, verbose=False)"
+    "basic_stats_processing(classification_file, workflow_id=5030, workflow_version=3.8, \n",
+    "                       remove_duplicates=True, outfile_csv=outfile_cleanclass, \n",
+    "                       keep_allcols=True, verbose=False)"
    ]
   },
   {
@@ -353,15 +367,6 @@
     "\n",
     "to see the syntax in that case. You can run this script each time you are about to aggregate your data on the latest classification export to produce a clean export with no duplicates (and only live classifications, if you wish) or to split a full project export into multiple based on workflows, or to extract only a specific workflow version from a workflow-specific extract. And, with each of these, if you keep `verbose` on, you'll get the stats for free."
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
fixes #30.

Allows user to do stats/clean files to include:
 - `workflow_version >= vmin`
 - `workflow_version <= vmax`
 - `vmin <= workflow_version <= vmax`

Tested using the `01 - Project Stats and Cleaning Classification Files` notebook, seems to work as expected.