### PR TITLE
Add touch table script

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ A survey of species from camera trap data in Kenya.
 #### Galaxy Zoo Touch Table
 Classifying galaxies according to shape on a touch table device.
 
-*Scripts* -- In order to prepare a device's local database, this script will read a Panoptes classification export csv and produce an appropriately parsed csv file that is ready for import as a database (.db) file.
+*Scripts* -- In order to prepare a device's local database, this script will read a Panoptes subject export csv and produce an appropriately parsed csv file that is ready for import as a database (.db) file.
 
 ### Older Scripts (Ouroboros-based)
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Some issues that all or most of these scripts address:
    - removing duplicate classifications (if they occur)
    - dealing with empty classifications (some projects throw them out, others count them as "nothing here" votes)
    - only including classifications from the most up-to-date workflow version(s)
-   
+
  For R code that addresses these issues, please see www.github.com/aliburchard/DataProcessing.
 
 #### [Andromeda Project Example Project](https://www.zooniverse.org/projects/lcjohnso/ap-aas229-test)
@@ -103,6 +103,11 @@ A survey of species from camera trap data in Kenya.
 *Scripts* -- Jailbreak survey annotations into a format more easily digestible by external scripts (1 line per species ID or "nothing here" classification), aggregate jailbroken annotations into a flattened CSV file with one line per subject. Also uses general utility scripts.
 
 *Marker type* -- Survey
+
+#### Galaxy Zoo Touch Table
+Classifying galaxies according to shape on a touch table device.
+
+*Scripts* -- In order to prepare a device's local database, this script will read a Panoptes classification export csv and produce an appropriately parsed csv file that is ready for import as a database (.db) file.
 
 ### Older Scripts (Ouroboros-based)
 

--- a/example_scripts/galaxy_zoo_touch_table/prepare_db_from_classification_export.py
+++ b/example_scripts/galaxy_zoo_touch_table/prepare_db_from_classification_export.py
@@ -28,11 +28,13 @@ def preprocessing():
                 if column in ['ra', 'dec', '!ra', '!dec']:
                     strippedPunctuation = column.strip(string.punctuation)
                     classifications.loc[index, strippedPunctuation] = row['metadata'][column]
+                if column in ['iauname', '!iauname']:
+                    classifications.loc[index, 'filename'] = row['metadata'][column]
             for column in row['locations']:
                 classifications.loc[index, 'image'] = row['locations'][column]
 
     # Drop unnecessary columns and rearrange
-    classifications = classifications[['subject_id', 'classifications_count', 'ra', 'dec', 'image', 'smooth', 'features', 'star']]
+    classifications = classifications[['subject_id', 'classifications_count', 'ra', 'dec', 'image', 'filename', 'smooth', 'features', 'star']]
 
     # Create a parsed CSV for DB import
     classifications.to_csv('parsed-subject-set.csv',sep=',',index = False,encoding='utf-8')

--- a/example_scripts/galaxy_zoo_touch_table/prepare_db_from_classification_export.py
+++ b/example_scripts/galaxy_zoo_touch_table/prepare_db_from_classification_export.py
@@ -9,8 +9,8 @@ def preprocessing():
     # Read the local CSV subject export
     classifications=pd.read_csv("classification-export.csv")
 
-    classifications['metadata']=classifications['metadata'].map(lambda x: json.loads(x))
-    classifications['locations']=classifications['locations'].map(lambda x: json.loads(x))
+    classifications['metadata']=classifications['metadata'].apply(lambda x: json.loads(x))
+    classifications['locations']=classifications['locations'].apply(lambda x: json.loads(x))
 
     # Include in subject_set_ids all subject sets you want to keep
     subject_set_ids = [];

--- a/example_scripts/galaxy_zoo_touch_table/prepare_db_from_classification_export.py
+++ b/example_scripts/galaxy_zoo_touch_table/prepare_db_from_classification_export.py
@@ -39,6 +39,6 @@ def preprocessing():
     classifications = classifications[['subject_id', 'classifications_count', 'ra', 'dec', 'image', 'filename', 'smooth', 'features', 'star']]
 
     # Create a parsed CSV for DB import
-    classifications.to_csv('parsed-subject-set.csv',sep=',',index = False,encoding='utf-8')
+    classifications.to_csv('parsed-subject-set.csv',index = False,encoding='utf-8')
 
 preprocessing()

--- a/example_scripts/galaxy_zoo_touch_table/prepare_db_from_classification_export.py
+++ b/example_scripts/galaxy_zoo_touch_table/prepare_db_from_classification_export.py
@@ -2,7 +2,7 @@
 import pandas as pd
 import json
 import string
-from tqdm import tqdm
+from tqdm import tqdm as progress_bar
 from itertools import cycle
 
 def preprocessing():
@@ -21,13 +21,15 @@ def preprocessing():
     classifications['star'] = 0;
 
     # Copy data from metadata into correct/new CSV headers with progress bar
-    with tqdm(total=len(classifications)) as pbar:
+    with progress_bar(total=len(classifications)) as current_progress:
         for index, row in classifications.iterrows():
-            pbar.update(1)
+            current_progress.update(1)
             for column in row['metadata']:
+                # Find the Right Ascension and Declination in the metadata and assign to columns
                 if column in ['ra', 'dec', '!ra', '!dec']:
-                    strippedPunctuation = column.strip(string.punctuation)
-                    classifications.loc[index, strippedPunctuation] = row['metadata'][column]
+                    stripped_punctuation = column.strip(string.punctuation)
+                    classifications.loc[index, stripped_punctuation] = row['metadata'][column]
+                # Find the image name, titled 'iauname', in the metadata and assign to a column
                 if column in ['iauname', '!iauname']:
                     classifications.loc[index, 'filename'] = row['metadata'][column]
             for column in row['locations']:

--- a/example_scripts/galaxy_zoo_touch_table/prepare_db_from_classification_export.py
+++ b/example_scripts/galaxy_zoo_touch_table/prepare_db_from_classification_export.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+import pandas as pd
+import json
+import string
+from tqdm import tqdm
+from itertools import cycle
+
+def preprocessing():
+    # Read the local CSV subject export
+    classifications=pd.read_csv("classification-export.csv")
+
+    classifications['metadata']=classifications['metadata'].map(lambda x: json.loads(x))
+    classifications['locations']=classifications['locations'].map(lambda x: json.loads(x))
+
+    # Include in subject_set_ids all subject sets you want to keep
+    subject_set_ids = [];
+    classifications = classifications.loc[classifications['subject_set_id'].isin(subject_set_ids)]
+
+    classifications['smooth'] = 0;
+    classifications['features'] = 0;
+    classifications['star'] = 0;
+
+    # Copy data from metadata into correct/new CSV headers with progress bar
+    with tqdm(total=len(classifications)) as pbar:
+        for index, row in classifications.iterrows():
+            pbar.update(1)
+            for column in row['metadata']:
+                if column in ['ra', 'dec', '!ra', '!dec']:
+                    strippedPunctuation = column.strip(string.punctuation)
+                    classifications.loc[index, strippedPunctuation] = row['metadata'][column]
+            for column in row['locations']:
+                classifications.loc[index, 'image'] = row['locations'][column]
+
+    # Drop unnecessary columns and rearrange
+    classifications = classifications[['subject_id', 'classifications_count', 'ra', 'dec', 'image', 'smooth', 'features', 'star']]
+
+    # Create a parsed CSV with headers removed for DB import
+    classifications.to_csv('parsed-subject-set.csv',sep=',',index = False,encoding='utf-8',header=False)
+
+preprocessing()

--- a/example_scripts/galaxy_zoo_touch_table/prepare_db_from_classification_export.py
+++ b/example_scripts/galaxy_zoo_touch_table/prepare_db_from_classification_export.py
@@ -34,7 +34,7 @@ def preprocessing():
     # Drop unnecessary columns and rearrange
     classifications = classifications[['subject_id', 'classifications_count', 'ra', 'dec', 'image', 'smooth', 'features', 'star']]
 
-    # Create a parsed CSV with headers removed for DB import
-    classifications.to_csv('parsed-subject-set.csv',sep=',',index = False,encoding='utf-8',header=False)
+    # Create a parsed CSV for DB import
+    classifications.to_csv('parsed-subject-set.csv',sep=',',index = False,encoding='utf-8')
 
 preprocessing()


### PR DESCRIPTION
This PR includes a script to parse a project's subject export from Panoptes and create a new CSV that will be used when preparing a local database (.db) file for the Galaxy Zoo touch table app to use. 

After creating a SQL table according to the [schema on the touch table repo](https://github.com/zooniverse/galaxy-zoo-touch-table), the parsed CSV created from this script can be uploaded to that SQL table, thus populating the table with data which become the touch table subjects.