### PR TITLE
Add utility scripts

### DIFF
--- a/utility_scripts/README.md
+++ b/utility_scripts/README.md
@@ -1,0 +1,13 @@
+# utility_scripts
+
+Scripts that perform various duties and tasks on Panoptes projects and project
+data exports.
+
+### Script Descriptions
+
+- `edit_metadata.py`: Add or edit fields in subject metadata for a given subject
+set or sets.  Edit Python script and run from command line.
+
+- `remove_combo_nesting.py`: Remove nested annotations that result from the use
+of the Combo task from a classification data export. Call Python script from
+command line and pass input variables via command line call.

--- a/utility_scripts/edit_metadata.py
+++ b/utility_scripts/edit_metadata.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+
+###################################
+# Script: Edit Metadata
+#
+# To Use:
+# 1) Edit input parameters below.
+# 2) Run from command line: `python edit_metadata.py`
+
+from panoptes_client import Panoptes, SubjectSet
+
+###################################
+# Input Parameters
+
+puser = 'USERNAME'
+ppswd = 'PASSWORD'
+subject_set_ids = [77172]
+new_metadata = {"Attribution": "Photos are open source under a CC BY 3.0 license and were contributed to the project via CitSci.org."}
+
+###################################
+
+Panoptes.connect(username=puser, password=ppswd)
+
+for ssid in subject_set_ids:
+    subject_set = SubjectSet.find(ssid)
+
+    print('Editing metadata for Subject Set #{0}: {1}'.format
+          (subject_set.raw['id'], subject_set.raw['display_name']))
+
+    for subject in subject_set.subjects:
+        for key, value in new_metadata.items():
+            subject.metadata[key]=value
+        subject.save()

--- a/utility_scripts/remove_combo_nesting.py
+++ b/utility_scripts/remove_combo_nesting.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+
+import csv
+import json
+import argparse
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description="Undo nesting of annotations for combo task")
+    parser.add_argument("--classification_export", required=True,
+                        help="Input Filename of Classification Export CSV")
+    parser.add_argument("--combo_task_id", required=True, help="Task ID for Combo Task")
+    parser.add_argument("--output_file", required=True, help="Output Filename for CSV")
+
+    args = parser.parse_args()
+    file_input = args.classification_export
+    file_output = args.output_file
+    combo_task_id = args.combo_task_id
+
+    with open(file_output, 'w') as csvout:
+        with open(file_input) as csvin:
+            classifications = csv.DictReader(csvin)
+            writer = csv.DictWriter(csvout, classifications.fieldnames)
+            writer.writeheader()
+            for c in classifications:
+                annotations = json.loads(c['annotations'])
+                for a in annotations: 
+                    if a['task'] == combo_task_id: 
+                        for t in a['value']: 
+                            annotations.append(t) 
+                        annotations.remove(a)
+                c['annotations']=annotations
+                writer.writerow(c)


### PR DESCRIPTION
Add new directory for utility scripts, including two python scripts written to solve recent data needs:

1. editing metadata for a subject set
2. remove nesting of annotations in classification export that result from combo task usage

Considering major reorganization of repo directories to better expose the different flavors of content here: end-to-end scripts for example projects, general purpose scripts for project data reduction, other scripts for various tasks.