### PR TITLE
Add floating forest coordinate parsing script

### DIFF
--- a/scripts_ProjectExamples/mapping_viz_tools/merge_coords.py
+++ b/scripts_ProjectExamples/mapping_viz_tools/merge_coords.py
@@ -1,0 +1,85 @@
+# INPUT: CSV with the following columns:
+#   lng_mean: Float, ex: -58.591
+#   lat_mean: Float, ex: -52.161
+#   polydict: Dictionary: ex: { lng: [-58.5931, -58.5933...], lat: [-52.1608, -52.1607...] }
+# OUTPUT: JSON with the following format:
+#   {
+#     "type": "FeaturesCollection",
+#       ...
+#     "features": [
+#       {
+#          "type": "Feature",
+#          "geometry": {
+#            "type"
+#            "coordinates": [3D array of lat/lon coordinates]
+#          }
+#       }
+#     ]
+#   }
+
+import pandas as pd
+import json
+import string
+from ast import literal_eval
+
+# process may not be needed for mapping viz, but keeping it here for reference
+def process():
+    items = pd.read_csv("ffpoly_select.csv")
+    items['polydict'] = items['polydict'].apply(literal_eval)
+    items['polydict'].apply(lambda x: type(x))
+
+    index = 0
+
+    for dict in items['polydict']:
+        merged = [[a, b] for a, b in zip(dict['lng'], dict['lat'])]
+        items.at[index, 'coords'] = str(merged)
+        index += 1
+
+    del items['lng_mean']
+    del items['lat_mean']
+    del items['polydict']
+    items.to_csv('merged_coords.csv',index = False,encoding='utf-8')
+
+def toGeoJSON():
+    items = pd.read_csv("ffpoly_select.csv")
+    items['polydict'] = items['polydict'].apply(literal_eval)
+    items['polydict'].apply(lambda x: type(x))
+
+    index = 0
+
+    geojson = {
+        'type':'FeatureCollection',
+        'crs': {
+            'type': 'EPSG',
+            'properties': {
+                'code': 4326,
+                'coordinate_order': [1, 0]
+            }
+        },
+        'features':[]}
+
+    for dict in items['polydict']:
+        merged = [[a, b] for a, b in zip(dict['lng'], dict['lat'])]
+        feature = {
+            'type': 'Feature',
+            "properties": {
+                "name": "Floating Forest Data"
+            },
+            'geometry': {
+                'type': 'Polygon',
+                'coordinates': [merged]
+            },
+            "style": {
+                "fill":"red",
+                "stroke-width":"3",
+                "fill-opacity":0.6
+            },
+        }
+        geojson['features'].append(feature)
+        index += 1
+
+    with open('coordinates.json', 'w') as output_file:
+        json.dump(geojson, output_file, indent=2)
+
+# process()
+toGeoJSON()

--- a/scripts_ProjectExamples/mapping_viz_tools/merge_coords.py
+++ b/scripts_ProjectExamples/mapping_viz_tools/merge_coords.py
@@ -41,6 +41,7 @@ def toGeoJSON():
         merged = [[a, b] for a, b in zip(dict['lng'], dict['lat'])]
         feature = {
             'type': 'Feature',
+            "tippecanoe" : { "layer" : "kelp" },
             "properties": {
                 "name": "Floating Forest Data"
             },
@@ -56,7 +57,7 @@ def toGeoJSON():
         }
         geojson['features'].append(feature)
 
-    with open('coordinates.json', 'w') as output_file:
+    with open('kelp.json', 'w') as output_file:
         json.dump(geojson, output_file, indent=2)
 
 toGeoJSON()

--- a/scripts_ProjectExamples/mapping_viz_tools/merge_coords.py
+++ b/scripts_ProjectExamples/mapping_viz_tools/merge_coords.py
@@ -22,30 +22,9 @@ import json
 import string
 from ast import literal_eval
 
-# process may not be needed for mapping viz, but keeping it here for reference
-def process():
-    items = pd.read_csv("ffpoly_select.csv")
-    items['polydict'] = items['polydict'].apply(literal_eval)
-    items['polydict'].apply(lambda x: type(x))
-
-    index = 0
-
-    for dict in items['polydict']:
-        merged = [[a, b] for a, b in zip(dict['lng'], dict['lat'])]
-        items.at[index, 'coords'] = str(merged)
-        index += 1
-
-    del items['lng_mean']
-    del items['lat_mean']
-    del items['polydict']
-    items.to_csv('merged_coords.csv',index = False,encoding='utf-8')
-
 def toGeoJSON():
     items = pd.read_csv("ffpoly_select.csv")
-    items['polydict'] = items['polydict'].apply(literal_eval)
-    items['polydict'].apply(lambda x: type(x))
-
-    index = 0
+    items['polydict'] = [json.loads(q.replace("'", '"')) for q in items.polydict]
 
     geojson = {
         'type':'FeatureCollection',
@@ -76,10 +55,8 @@ def toGeoJSON():
             },
         }
         geojson['features'].append(feature)
-        index += 1
 
     with open('coordinates.json', 'w') as output_file:
         json.dump(geojson, output_file, indent=2)
 
-# process()
 toGeoJSON()


### PR DESCRIPTION
I'm no Python pro, so there could very well be a better way of doing this. Also, I kept in a `process` method I initially played with solely for reference, but it isn't used by this script, so I'm open to removing it as well.

The idea here is that I'll take a .csv containing lat/lon coordinates of polygon shapes relating to where volunteers have marked kelp. This script will then parse that csv and into a GeoJSON format that can then be used by [tippecanoe](https://github.com/mapbox/tippecanoe) to create mbtiles. This is the [first step](https://github.com/zooniverse/zoomapper/wiki/How-Can-I-Create-Custom-Tiles%3F) in creating custom tiles.

Let me know if you need that .csv document again to test this. 