### PR TITLE
Add subject image download script

### DIFF
--- a/scripts_Utility/README.md
+++ b/scripts_Utility/README.md
@@ -13,6 +13,9 @@ team member is required for use.
 - `delete_subjects.py`: Delete subjects (permanently!) selected based on subject
 set ID and range of subject IDs.  Edit Python script and run from command line.
 
+- `download_subject_images.py`: Download images from existing subjects for input
+subject set ID.  Edit Python script and run from command line.
+
 - `duplicate_subjects.py`: Create duplicate subjects given a list of existing
 subject IDs. New subjects are added to a specified project and subject set.
 

--- a/scripts_Utility/download_subject_images.py
+++ b/scripts_Utility/download_subject_images.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+
+from panoptes_client import Panoptes, SubjectSet, Subject
+import urllib.request
+import os
+
+#################
+# INPUT PARAMS
+
+# Input and Output Values
+subject_set_id = 94047 # Subject Set ID
+dir_imgraw = 'imgraw_94047' # Destination for images
+
+# Zooniverse Login
+puser = 'USERNAME'
+ppswd = 'PASSWORD'
+
+#################
+# SCRIPT CODE
+
+Panoptes.connect(username=puser, password=ppswd)
+
+if not os.path.exists(dir_imgraw):
+    os.makedirs(dir_imgraw)
+
+ss = SubjectSet.find(subject_set_id)
+
+for s in ss.subjects:
+    
+    n_frames = len(s.locations)
+
+    for index,loc in enumerate(s.locations):
+        if n_frames == 1:
+            imfile = dir_imgraw+'/{}.jpg'.format(s.id)
+        else:
+            imfile = dir_imgraw+'/{}_{}.jpg'.format(s.id,index)
+        while not os.path.exists(imfile):
+            try:
+                for img_mimetype,img_url in loc.items():
+                    urllib.request.urlretrieve(img_url, imfile)
+            except urllib.error.HTTPError as exception:
+                print('ERROR - '+s.id+': '+str(exception.reason))


### PR DESCRIPTION
New utility script: use the Panoptes Python Client to download all subject images for a given subject set.  The script allows for single or multi-frame subjects.